### PR TITLE
feat: unify JP number formatting (percent & JPY)

### DIFF
--- a/src/app/demo/[name]/ui/area-chart.tsx
+++ b/src/app/demo/[name]/ui/area-chart.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Area, AreaChart, CartesianGrid, XAxis } from "recharts";
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
 
 import {
   Card,
@@ -18,6 +18,7 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
+import { formatNumber } from "@/lib/format";
 import {
   Select,
   SelectContent,
@@ -226,10 +227,12 @@ export function AreaChartComponent() {
                 });
               }}
             />
+            <YAxis tickFormatter={(v) => formatNumber(v)} />
             <ChartTooltip
               cursor={false}
               content={
                 <ChartTooltipContent
+                  formatter={(v) => formatNumber(Number(v))}
                   labelFormatter={(value) => {
                     return new Date(value).toLocaleDateString("en-US", {
                       month: "short",

--- a/src/app/demo/[name]/ui/bar-chart.tsx
+++ b/src/app/demo/[name]/ui/bar-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
 
 import {
   Card,
@@ -18,6 +18,7 @@ import {
   ChartTooltipContent,
 } from "@/components/ui/chart";
 import * as React from "react";
+import { formatNumber } from "@/lib/format";
 
 const chartData = [
   { month: "January", desktop: 186, mobile: 80 },
@@ -59,7 +60,8 @@ export function BarChartComponent() {
               tickMargin={10}
               tickFormatter={(value) => value.slice(0, 3)}
             />
-            <ChartTooltip content={<ChartTooltipContent />} />
+            <YAxis tickFormatter={(v) => formatNumber(v)} />
+            <ChartTooltip formatter={(v) => formatNumber(Number(v))} content={<ChartTooltipContent />} />
             <ChartLegend content={<ChartLegendContent />} />
             <Bar dataKey="desktop" fill="var(--color-desktop)" radius={4} />
             <Bar dataKey="mobile" fill="var(--color-mobile)" radius={4} />

--- a/src/app/demo/[name]/ui/data-table-payments.tsx
+++ b/src/app/demo/[name]/ui/data-table-payments.tsx
@@ -17,6 +17,7 @@ import * as React from "react";
 
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { formatCurrencyJPY } from "@/lib/format";
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -125,15 +126,13 @@ export const columns: ColumnDef<Payment>[] = [
     accessorKey: "amount",
     header: () => <div className="text-right">Amount</div>,
     cell: ({ row }) => {
-      const amount = Number.parseFloat(row.getValue("amount"));
+      const amount = row.getValue<number>("amount") ?? null;
 
-      // Format the amount as a dollar amount
-      const formatted = new Intl.NumberFormat("en-US", {
-        style: "currency",
-        currency: "USD",
-      }).format(amount);
-
-      return <div className="text-right font-medium">{formatted}</div>;
+      return (
+        <div className="text-right font-medium">
+          {formatCurrencyJPY(amount)}
+        </div>
+      );
     },
   },
   {

--- a/src/app/demo/[name]/ui/pie-chart.tsx
+++ b/src/app/demo/[name]/ui/pie-chart.tsx
@@ -116,7 +116,7 @@ export function PieChartComponent() {
       </CardContent>
       <CardFooter className="flex-col gap-2 text-sm">
         <div className="flex items-center gap-2 font-medium leading-none">
-          Trending up by 5.2% this month <TrendingUp className="h-4 w-4" />
+          Trending up by <NumberText value={0.052} kind="percent" /> this month <TrendingUp className="h-4 w-4" />
         </div>
         <div className="text-muted-foreground leading-none">
           Showing total visitors for the last 6 months

--- a/src/app/demo/[name]/ui/pie-chart.tsx
+++ b/src/app/demo/[name]/ui/pie-chart.tsx
@@ -12,6 +12,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import NumberText from "@/components/number-text";
 import {
   type ChartConfig,
   ChartContainer,
@@ -95,7 +96,7 @@ export function PieChartComponent() {
                           y={viewBox.cy}
                           className="fill-foreground font-bold text-3xl"
                         >
-                          {totalVisitors.toLocaleString()}
+                          <NumberText value={totalVisitors} kind="number" as="text" />
                         </tspan>
                         <tspan
                           x={viewBox.cx}

--- a/src/app/demo/[name]/ui/table.tsx
+++ b/src/app/demo/[name]/ui/table.tsx
@@ -8,6 +8,18 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { formatCurrencyJPY } from "@/lib/format";
+
+const toNumberFromCurrency = (
+  raw: string | number | null | undefined,
+): number | null => {
+  if (typeof raw === "number") return raw;
+  if (typeof raw === "string") {
+    const n = parseFloat(raw.replace(/[^0-9.-]+/g, ""));
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+};
 
 const invoices = [
   {
@@ -75,7 +87,7 @@ export const table = {
               <TableCell>{invoice.paymentStatus}</TableCell>
               <TableCell>{invoice.paymentMethod}</TableCell>
               <TableCell className="text-right">
-                {invoice.totalAmount}
+                {formatCurrencyJPY(toNumberFromCurrency(invoice.totalAmount))}
               </TableCell>
             </TableRow>
           ))}
@@ -83,7 +95,7 @@ export const table = {
         <TableFooter>
           <TableRow>
             <TableCell colSpan={3}>Total</TableCell>
-            <TableCell className="text-right">$2,500.00</TableCell>
+            <TableCell className="text-right">{formatCurrencyJPY(2500)}</TableCell>
           </TableRow>
         </TableFooter>
       </Table>

--- a/src/components/number-text.tsx
+++ b/src/components/number-text.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { formatCurrencyJPY, formatNumber, formatPercent } from "@/lib/format";
+
+type Props = {
+  value: number | string | null | undefined;
+  kind?: "percent" | "jpy" | "number";
+  digits?: number;
+  className?: string;
+  as?: "span" | "text";
+};
+
+const toNum = (v: number | string | null | undefined): number | null => {
+  if (typeof v === "number") return v;
+  if (typeof v === "string") {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+};
+
+export default function NumberText({
+  value,
+  kind = "number",
+  digits,
+  className,
+  as = "span",
+}: Props) {
+  const n = toNum(value);
+  const d = digits ?? (kind === "percent" ? 1 : 0);
+
+  let content: string;
+  if (kind === "percent") content = formatPercent(n, d);
+  else if (kind === "jpy") content = formatCurrencyJPY(n);
+  else content = typeof value === "string" ? value : formatNumber(n, d);
+
+  if (as === "text") return <>{content}</>;
+  return <span className={className}>{content}</span>;
+}
+
+

--- a/src/components/product-grid.tsx
+++ b/src/components/product-grid.tsx
@@ -7,7 +7,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import type { Product } from "@/lib/products";
-import { formatCurrencyJPY } from "@/lib/format";
+import NumberText from "@/components/number-text";
 
 export default function ProductGrid({
   categories,
@@ -59,7 +59,9 @@ export default function ProductGrid({
             </CardContent>
 
             <CardFooter className="flex items-center justify-between p-4 pt-0">
-              <div className="font-semibold">{formatCurrencyJPY(product.price)}</div>
+              <div className="font-semibold">
+                <NumberText value={product.price} kind="jpy" />
+              </div>
               <Button size="sm">
                 <ShoppingCart className="mr-2 size-4" /> Add
               </Button>

--- a/src/components/product-grid.tsx
+++ b/src/components/product-grid.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import type { Product } from "@/lib/products";
+import { formatCurrencyJPY } from "@/lib/format";
 
 export default function ProductGrid({
   categories,
@@ -58,7 +59,7 @@ export default function ProductGrid({
             </CardContent>
 
             <CardFooter className="flex items-center justify-between p-4 pt-0">
-              <div className="font-semibold">${product.price.toFixed(2)}</div>
+              <div className="font-semibold">{formatCurrencyJPY(product.price)}</div>
               <Button size="sm">
                 <ShoppingCart className="mr-2 size-4" /> Add
               </Button>

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import NumberText from "@/components/number-text";
 import * as RechartsPrimitive from "recharts";
 
 import { cn } from "@/lib/utils";

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -232,9 +232,9 @@ function ChartTooltipContent({
                         {itemConfig?.label || item.name}
                       </span>
                     </div>
-                    {item.value && (
+                    {item.value !== undefined && (
                       <span className="font-medium font-mono text-foreground tabular-nums">
-                        {item.value.toLocaleString()}
+                        <NumberText value={item.value as number | string} kind="number" />
                       </span>
                     )}
                   </div>

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,39 @@
+// src/lib/format.ts
+/**
+ * 表示用フォーマッタ（日本向け）
+ * - 表示のみ変更するため、値は変換しない（計算ロジック不変）
+ * - null/undefined/NaN は "—" を返す（UIでの空表示）
+ */
+
+/**
+ * パーセント表示（例: 0.948 -> "94.8%")
+ * @param v - 0..1 の小数
+ * @param digits - 小数点以下桁数（デフォルト 1）
+ */
+export function formatPercent(v: number | null | undefined, digits = 1): string {
+  if (v === null || v === undefined || Number.isNaN(v)) return "—";
+  const n = v * 100;
+  // 少数桁を固定表示（例: 94.8）
+  return `${n.toFixed(digits)}%`;
+}
+
+/**
+ * 日本円表示（例: 27663.496 -> "27,663円"）
+ * - 四捨五入して整数に（表示のみ）
+ */
+export function formatCurrencyJPY(v: number | null | undefined): string {
+  if (v === null || v === undefined || Number.isNaN(v)) return "—";
+  const n = Math.round(v);
+  const s = new Intl.NumberFormat("ja-JP", { maximumFractionDigits: 0 }).format(n);
+  return `${s}円`;
+}
+
+/**
+ * 汎用数値フォーマット（桁区切り、小数桁指定）
+ */
+export function formatNumber(v: number | null | undefined, digits = 0): string {
+  if (v === null || v ===undefined || Number.isNaN(v)) return "—";
+  return new Intl.NumberFormat("ja-JP", { maximumFractionDigits: digits }).format(v);
+}
+
+


### PR DESCRIPTION
Changes: Tables (formatCurrencyJPY), Metrics (NumberText + SVG-safe as="text"), Charts (seed: YAxis/Tooltip formatting).\n\nSpecs:\n- Percent: 1 decimal place (formatPercent)\n- JPY: round to integer + thousands separator + '円' (formatCurrencyJPY)\n- Number: thousands separator (formatNumber)\n\nNotes: Display-only changes; calculations/sorting/filtering remain unchanged.\n\nChecklist:\n- [ ] Tables updated\n- [ ] Metrics updated\n- [ ] Charts seeded\n